### PR TITLE
obs_state_refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ while not jnp.all(ep_dones):
     # In case at least one episode is done, reset the state of the done episodes only
     if jnp.any(ep_dones):
         rng, key = jax.random.split(rng, 2)
-        obs, states = env.reset_done_episodes(state, obs, ep_dones, key)
+        obs, state = env.reset_done_episodes(obs, state, ep_dones, key)
 ```
 
 ## 🎭 Scenarios 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -73,7 +73,7 @@ def run_single_no_scan(env, params, n_steps, repeats=1):
                 actions = jnp.zeros((env.n_agents, env.action_space.shape[0]))
             else:
                 actions = params.apply_fn(params.params, obs)
-            states, obs, r, a, d = env.step(states, actions, key)
+            obs, states, r, a, d = env.step(states, actions, key)
     obs.block_until_ready()
 
 
@@ -87,7 +87,7 @@ def run_single_scan(env, params, n_steps, repeats=1):
         else:
             actions = params.apply_fn(params.params, obs)
         rng, key = jax.random.split(rng, 2)
-        states, obs, r, a, d = env.step(states, actions, key)
+        obs, states, r, a, d = env.step(states, actions, key)
         carry = [states, obs, rng]
         return carry, []
 

--- a/examples/calibrate_throttle.py
+++ b/examples/calibrate_throttle.py
@@ -34,7 +34,7 @@ def loop_throttle():
             a7 = GigastepEnv.action(speed=-1, dive=1)
             action = jnp.stack([a1, a2, a3,a4,a5,a6,a7], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return

--- a/examples/demo_features.py
+++ b/examples/demo_features.py
@@ -28,7 +28,7 @@ def loop_2agents_altitude():
             a3 = GigastepEnv.action(speed=1, dive=1 if t > 10 else 0)
             action = jnp.stack([a1, a2, a3], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -56,7 +56,7 @@ def loop_speed_up_slow_down():
             a3 = GigastepEnv.action(speed=1 if t > 10 else 0)
             action = jnp.stack([a1, a2, a3], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -98,7 +98,7 @@ def loop_collide_direct():
             a8 = GigastepEnv.action(speed=1)
             action = jnp.stack([a1, a2, a3, a4, a5, a6, a7, a8], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -117,12 +117,12 @@ def loop_random_agents():
 
     key, rng = jax.random.split(rng, 2)
     while True:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         while jnp.sum(dyn.get_dones(state)) > 0:
             rng, key = jax.random.split(rng, 2)
             action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -140,7 +140,7 @@ def loop_reset_states():
 
     while True:
         key, rng = jax.random.split(rng, 2)
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         viewer.draw(dyn, state, obs)
         if viewer.should_pause:
             return
@@ -173,7 +173,7 @@ def loop_visible_debug():
         action = [GigastepEnv.action(speed=0) for s in range(state[0]["x"].shape[0])]
         action = jnp.stack(action, axis=0)
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         if viewer.should_pause:
             return
@@ -251,7 +251,7 @@ def loop_agent_sprites():
         # )
         action = jnp.zeros((state[0]["x"].shape[0], 3))
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         if viewer.should_pause:
             return
@@ -295,7 +295,7 @@ def loop_collision_with_offset():
             a8 = GigastepEnv.action(speed=1)
             action = jnp.stack([a1, a2, a3, a4, a5, a6, a7, a8], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -315,13 +315,13 @@ def loop_maps():
 
     key, rng = jax.random.split(rng, 2)
     while True:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         t = 0
         while jnp.sum(dyn.get_dones(state)) > 0:
             rng, key = jax.random.split(rng, 2)
             action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -350,7 +350,7 @@ def loop_heading():
             a2 = GigastepEnv.action(speed=1)
             action = jnp.stack([a1, a2], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             print("Health", state[0]["health"])
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
@@ -371,12 +371,12 @@ def loop_communication():
 
     key, rng = jax.random.split(rng, 2)
     while True:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         while jnp.sum(dyn.get_dones(state)) > 0:
             action = jnp.zeros((n_agents, 3))
             rng, key = jax.random.split(rng, 2)
             # Don't update state
-            _state, obs, r, a, d = dyn.step(state, action, key)
+            obs, _state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             if viewer.should_pause:
                 return
@@ -384,7 +384,7 @@ def loop_communication():
                 sys.exit(1)
             if viewer.should_reset:
                 rng, key = jax.random.split(rng, 2)
-                state = dyn.reset(key)
+                obs, state = dyn.reset(key)
             time.sleep(SLEEP_TIME)
 
 

--- a/examples/gen_video.py
+++ b/examples/gen_video.py
@@ -39,7 +39,7 @@ def loop_2agents():
         a2 = GigastepEnv.action(speed=1)
         action = jnp.stack([a1, a2], axis=0)
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         save_frame(dyn, state, obs, f"video/2agents/frame_{frame:04d}.png", obs2=True)
         frame += 1
@@ -61,7 +61,7 @@ def loop_some_agents():
     while jnp.sum(dyn.get_dones(state)) > 0:
         action = jnp.zeros((6, 3))
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         save_frame(
             dyn, state, obs, f"video/some_agents/frame_{frame:04d}.png", obs2=True
@@ -109,12 +109,12 @@ def loop_random_agents():
     frame = 0
     t = 0
     while frame < 120:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         while jnp.sum(dyn.get_dones(state)) > 0:
             rng, key = jax.random.split(rng, 2)
             action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             save_frame(
                 dyn,
                 state,
@@ -143,13 +143,13 @@ def loop_random_many_agents():
     os.makedirs("video/many", exist_ok=True)
     viewer = GigastepViewer(2 * res, show_num_agents=3)
 
-    state, obs = dyn.reset(key)
+    obs, state = dyn.reset(key)
     frame = 0
     while jnp.sum(dyn.get_dones(state)) > 0:
         rng, key = jax.random.split(rng, 2)
         action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         save_frame(dyn, state, obs, f"video/many/frame_{frame:04d}.png")
         viewer.draw(dyn, state, obs)
         frame += 1
@@ -181,7 +181,7 @@ def loop_visible_debug():
         action = [GigastepEnv.action(speed=0) for s in range(state[0]["x"].shape[0])]
         action = jnp.stack(action, axis=0)
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         save_frame(dyn, state, obs, f"video/visibility/frame_{frame:04d}.png")
         frame += 1
@@ -210,7 +210,7 @@ def loop_2agents_altitude():
         t = t + 1
         action = jnp.stack([a1, a2, a3], axis=0)
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         save_frame(dyn, state, obs, f"video/dive/frame_{frame:04d}.png", obs1=False)
         frame += 1
@@ -229,13 +229,13 @@ def loop_maps():
     key, rng = jax.random.split(rng, 2)
     frame = 0
     while True:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         t = 0
         while jnp.sum(dyn.get_dones(state)) > 0:
             rng, key = jax.random.split(rng, 2)
             action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             viewer.draw(dyn, state, obs)
             save_frame(dyn, state, obs, f"video/maps/frame_{frame:04d}.png", obs1=True)
             frame += 1
@@ -269,7 +269,7 @@ def loop_heterogenous():
         state = stack_agents(s1, s2, s3)
         action = jnp.zeros((3, 3))
         rng, key = jax.random.split(rng, 2)
-        state, obs, r, a, d = dyn.step(state, action, key)
+        obs, state, r, a, d = dyn.step(state, action, key)
         viewer.draw(dyn, state, obs)
         for i in range(5):
             save_frame(

--- a/examples/human_vs_circling.py
+++ b/examples/human_vs_circling.py
@@ -40,7 +40,7 @@ def loop_user():
             a2 = jnp.repeat(jnp.array([[1, 0, 0]]), 8, axis=0)
             action = jnp.concatenate([a1[None, :], a2], axis=0)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, ep_done = dyn.step(state, action, key)
+            obs, state, r, a, ep_done = dyn.step(state, action, key)
             frame_buffer = viewer.draw(dyn, state, obs)
             frames.append(Image.fromarray(frame_buffer))
             print("len(frames)", len(frames))

--- a/examples/run_human.py
+++ b/examples/run_human.py
@@ -11,13 +11,13 @@ from PIL import Image
 def loop_user():
     viewer = GigastepViewer(84 * 4, show_num_agents=1)
     viewer.set_title("User input")
-    env = make_scenario("hide_and_seek_5_vs_5_det")
+    env = make_scenario("hide_and_seek_5_vs_5")
     # env = make_scenario("waypoint_5_vs_5")
     rng = jax.random.PRNGKey(1)
     frames = []
     while True:
         rng, key = jax.random.split(rng, 2)
-        state, obs = env.reset(key)
+        obs, state = env.reset(key)
         t = 0
         ep_done = False
         while not ep_done:
@@ -30,7 +30,7 @@ def loop_user():
             is_ego = jnp.arange(env.n_agents) == 0
             action = jnp.where(is_ego[:, None], a1, a2)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, ep_done = env.step(state, action, key)
+            obs, state, r, a, ep_done = env.step(state, action, key)
             print(f"Step {t:04d} reward {r[0]:0.1f}")
             frame_buffer = viewer.draw(env, state, obs)
             t += 1

--- a/examples/run_viewer.py
+++ b/examples/run_viewer.py
@@ -15,7 +15,7 @@ def loop_user():
     rng = jax.random.PRNGKey(1)
     while True:
         key, rng = jax.random.split(rng, 2)
-        state, obs = env.reset(key)
+        obs, state = env.reset(key)
         ep_done = False
         t = 0
         while not ep_done and t < 50:
@@ -24,7 +24,7 @@ def loop_user():
             a2 = jax.random.uniform(key, shape=(env.n_agents, 3), minval=-1, maxval=1)
             action = jnp.where(jnp.arange(env.n_agents)[:, None] == 0, a1, a2)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, ep_done = env.step(state, action, key)
+            obs, state, r, a, ep_done = env.step(state, action, key)
             viewer.draw(env, state, obs)
             if viewer.should_reset:
                 break

--- a/examples/simple_es.py
+++ b/examples/simple_es.py
@@ -25,7 +25,7 @@ def circle_vs_straight(env):
     while True:
         ep_done = False
         key, rng = jax.random.split(rng, 2)
-        state, obs = env.reset(key)
+        obs, state = env.reset(key)
         while not ep_done:
             rng, key, key2 = jax.random.split(rng, 3)
             action_ego = jnp.zeros((env.n_agents, 3))
@@ -35,7 +35,7 @@ def circle_vs_straight(env):
             action = evaluator.merge_actions(action_ego, action_opp)
 
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, dones, ep_done = env.step(state, action, key)
+            obs, state, r, dones, ep_done = env.step(state, action, key)
             evaluator.update_step(r, dones, ep_done)
 
             img = viewer.draw(env, state, obs)
@@ -90,7 +90,7 @@ def replay_policy(env, params):
                 action = evaluator.merge_actions(action_ego, action_opp)
 
                 rng, key = jax.random.split(rng, 2)
-                state, obs, r, dones, ep_done = env.step(state, action, key)
+                obs, state, r, dones, ep_done = env.step(state, action, key)
                 evaluator.update_step(r, dones, ep_done)
 
                 img = viewer.draw(env, state, obs)

--- a/examples/test_batch.py
+++ b/examples/test_batch.py
@@ -14,7 +14,7 @@ rng = jax.random.PRNGKey(3)
 rng, key_reset = jax.random.split(rng, 2)
 key_reset = jax.random.split(key_reset, batch_size)
 
-state, obs = env.v_reset(key_reset)
+obs, state = env.v_reset(key_reset)
 ep_dones = jnp.zeros(batch_size, dtype=jnp.bool_)
 load_policy = False
 if load_policy:
@@ -44,15 +44,15 @@ while True:
         action = jax.random.uniform(key_action, shape=(batch_size, env.n_agents, 3), minval=-1, maxval=1)
         action = jax.numpy.zeros((batch_size, env.n_agents, 3))
     key_step = jax.random.split(key_step, batch_size)
-    state, obs, rewards, dones, ep_dones = env.v_step(state, action, key_step)
+    obs, state, rewards, dones, ep_dones = env.v_step(state, action, key_step)
 
     if jnp.any(ep_dones):
         rng, key = jax.random.split(rng, 2)
-        state, obs = env.reset_done_episodes(state, obs, ep_dones, key)
+        obs, state = env.reset_done_episodes(obs, state, ep_dones, key)
 
     if viewer.should_quit:
         sys.exit(1)
-    print(state[0]["team"])
+    # print(state[0]["team"])
     print(rewards)
     # obs is an uint8 array of shape [batch_size, n_agents, 84,84,3]
     # rewards is a float32 array of shape [batch_size, n_agents]

--- a/examples/test_curriculum.py
+++ b/examples/test_curriculum.py
@@ -6,14 +6,14 @@ rng = jax.random.PRNGKey(3)
 rng, key_reset = jax.random.split(rng, 2)
 
 ep_done = False
-state, obs = env.reset(key_reset)
+obs, state = env.reset(key_reset)
 state = env.set_aux_reward_factor(state, 0.5)
 while not ep_done:
     rng, key_action, key_step = jax.random.split(rng, 3)
     action = jax.random.uniform(
         key_action, shape=(env.n_agents, 3), minval=-1, maxval=1
     )
-    state, obs, rewards, dones, ep_done = env.step(state, action, key_step)
+    obs, state, rewards, dones, ep_done = env.step(state, action, key_step)
     # obs is an uint8 array of shape [n_agents, 84,84,3]
     # rewards is a float32 array of shape [n_agents]
     # dones is a bool array of shape [n_agents]
@@ -30,7 +30,7 @@ rng = jax.random.PRNGKey(3)
 rng, key_reset = jax.random.split(rng, 2)
 key_reset = jax.random.split(key_reset, batch_size)
 
-state, obs = env.v_reset(key_reset)
+obs, state = env.v_reset(key_reset)
 state = env.v_set_aux_reward_factor(state, 0.5)
 
 ep_dones = jnp.zeros(batch_size, dtype=jnp.bool_)
@@ -40,7 +40,7 @@ while not jnp.all(ep_dones):
         key_action, shape=(batch_size, env.n_agents, 3), minval=-1, maxval=1
     )
     key_step = jax.random.split(key_step, batch_size)
-    state, obs, rewards, dones, ep_dones = env.v_step(state, action, key_step)
+    obs, state, rewards, dones, ep_dones = env.v_step(state, action, key_step)
     # obs is an uint8 array of shape [batch_size, n_agents, 84,84,3]
     # rewards is a float32 array of shape [batch_size, n_agents]
     # dones is a bool array of shape [batch_size, n_agents]
@@ -49,4 +49,5 @@ while not jnp.all(ep_dones):
     # In case at least one episode is done, reset the state of the done episodes only
     if jnp.any(ep_dones):
         rng, key = jax.random.split(rng, 2)
-        states, obs = env.reset_done_episodes(state, obs, ep_dones, key)
+        obs, state = env.reset_done_episodes(obs, state, ep_dones, key)
+        

--- a/examples/test_evaluator.py
+++ b/examples/test_evaluator.py
@@ -53,7 +53,7 @@ def loop_env(env, policy = None, device = "cpu", headless = False):
         for ep_idx in range(5):
             ep_done = False
             key, rng = jax.random.split(rng, 2)
-            state, obs = env.reset(key)
+            obs, state = env.reset(key)
             while not ep_done:
                 rng, key, key2 = jax.random.split(rng, 3)
                 if policy is None:
@@ -73,7 +73,7 @@ def loop_env(env, policy = None, device = "cpu", headless = False):
                 action = evaluator.merge_actions(action_ego, action_opp)
 
                 rng, key = jax.random.split(rng, 2)
-                state, obs, r, dones, ep_done = env.step(state, action, key)
+                obs, state, r, dones, ep_done = env.step(state, action, key)
                 evaluator.update_step(r, dones, ep_done)
                 if not headless:
                     img = viewer.draw(env, state, obs)
@@ -109,7 +109,7 @@ def loop_env_vectorized(env, policy = None, device = "cpu"):
             ep_done = np.zeros(batch_size, dtype=jnp.bool_)
             key, rng = jax.random.split(rng, 2)
             key = jax.random.split(key, batch_size)
-            state, obs = env.v_reset(key)
+            obs, state = env.v_reset(key)
             t = 0
             
             recurrent_hidden_states = torch.zeros(env.n_teams[0], 
@@ -136,7 +136,7 @@ def loop_env_vectorized(env, policy = None, device = "cpu"):
 
                 rng, key = jax.random.split(rng, 2)
                 key = jax.random.split(key, batch_size)
-                state, obs, r, dones, ep_done = env.v_step(state, action, key)
+                obs, state, r, dones, ep_done = env.v_step(state, action, key)
                 evaluator.update_step(r, dones, ep_done)
 
                 time.sleep(SLEEP_TIME)

--- a/examples/test_obs_type.py
+++ b/examples/test_obs_type.py
@@ -6,14 +6,14 @@ rng = jax.random.PRNGKey(3)
 rng, key_reset = jax.random.split(rng, 2)
 
 ep_done = False
-state, obs = env.reset(key_reset)
+obs, state = env.reset(key_reset)
 t = 0
 while not ep_done:
     rng, key_action, key_step = jax.random.split(rng, 3)
     action = jax.random.uniform(
         key_action, shape=(env.n_agents, 3), minval=-1, maxval=1
     )
-    state, obs, rewards, dones, ep_done = env.step(state, action, key_step)
+    obs, state, rewards, dones, ep_done = env.step(state, action, key_step)
     if t <= 1:
         print("obs.shape", obs.shape)
         for i in range(20):
@@ -36,7 +36,7 @@ rng = jax.random.PRNGKey(3)
 rng, key_reset = jax.random.split(rng, 2)
 key_reset = jax.random.split(key_reset, batch_size)
 
-state, obs = env.v_reset(key_reset)
+obs, state = env.v_reset(key_reset)
 ep_dones = jnp.zeros(batch_size, dtype=jnp.bool_)
 t = 0
 while not jnp.all(ep_dones):
@@ -45,7 +45,7 @@ while not jnp.all(ep_dones):
         key_action, shape=(batch_size, env.n_agents, 3), minval=-1, maxval=1
     )
     key_step = jax.random.split(key_step, batch_size)
-    state, obs, rewards, dones, ep_dones = env.v_step(state, action, key_step)
+    obs, state, rewards, dones, ep_dones = env.v_step(state, action, key_step)
     # obs is an uint8 array of shape [batch_size, n_agents, 84,84,3]
     # rewards is a float32 array of shape [batch_size, n_agents]
     # dones is a bool array of shape [batch_size, n_agents]
@@ -59,4 +59,4 @@ while not jnp.all(ep_dones):
     # In case at least one episode is done, reset the state of the done episodes only
     if jnp.any(ep_dones):
         rng, key = jax.random.split(rng, 2)
-        states, obs = env.reset_done_episodes(state, obs, ep_dones, key)
+        obs, states = env.reset_done_episodes(obs, state, ep_dones, key)

--- a/examples/test_scenarios.py
+++ b/examples/test_scenarios.py
@@ -18,7 +18,7 @@ def loop_env(env):
     frame_idx = 0
     os.makedirs("video/scenario", exist_ok=True)
     while True:
-        state, obs = env.reset(key)
+        obs, state = env.reset(key)
         ep_done = False
         t = 0
         # while not ep_done and t < 50:
@@ -29,7 +29,7 @@ def loop_env(env):
             )
             # action = jnp.zeros((env.n_agents, 3))
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = env.step(state, action, key)
+            obs, state, r, a, d = env.step(state, action, key)
             img = viewer.draw(env, state, obs)
 
             img = img[0 : 2 * img.shape[0] // 3]
@@ -53,7 +53,7 @@ def loop_env(env):
 
 if __name__ == "__main__":
     # convert -delay 3 -loop 0 video/scenario/frame_*.png video/scenario.webp
-    loop_env(env=make_scenario("waypoint_5_vs_5_det", use_stochastic_comm=False))
+    loop_env(env=make_scenario("waypoint_5_vs_5", use_stochastic_comm=False))
     # loop_env(env=make_scenario("special_20_vs_20", use_stochastic_comm=False))
     # loop_env(env = make_scenario("identical_20_vs_20"))
     # loop_env(env = make_scenario("identical_20_vs_20"))

--- a/examples/test_stacked_env.py
+++ b/examples/test_stacked_env.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     rng = jax.random.PRNGKey(1)
     rng, key = jax.random.split(rng, 2)
     key = jax.random.split(key, batch_size)
-    states, obs = env_stack.v_reset(key)
+    obs, states = env_stack.v_reset(key)
     t = 0
     while True:
         t += 1
@@ -26,11 +26,11 @@ if __name__ == "__main__":
         rng, key = jax.random.split(rng, 2)
         key = jax.random.split(key, batch_size)
 
-        states, obs, r, d, ep_dones = env_stack.v_step(states, actions, key)
+        obs, states, r, d, ep_dones = env_stack.v_step(states, actions, key)
 
         print(f"t= {t}, ep_dones", ep_dones)
         # time.sleep(0.5)
         if jnp.any(ep_dones):
             print("resetting")
             rng, key = jax.random.split(rng, 2)
-            states, obs = env_stack.reset_done_episodes(states, obs, ep_dones, key)
+            obs, states = env_stack.reset_done_episodes(obs, states, ep_dones, key)

--- a/examples/test_swarm.py
+++ b/examples/test_swarm.py
@@ -59,12 +59,13 @@ def loop_random_agents():
     key, rng = jax.random.split(rng, 2)
     frameid = 0
     while True:
-        state, obs = dyn.reset(key)
+        obs, state = dyn.reset(key)
         while jnp.sum(dyn.get_dones(state)) > 0:
+            print(frameid)
             rng, key = jax.random.split(rng, 2)
             action = jax.random.uniform(key, shape=(n_agents, 3), minval=-1, maxval=1)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, d = dyn.step(state, action, key)
+            obs, state, r, a, d = dyn.step(state, action, key)
             frame = viewer.draw(dyn, state, obs)
             save_frame(
                 dyn, state, obs, f"video/1000agents/frame_{frameid:04d}.png", obs1=True

--- a/examples/test_torch.py
+++ b/examples/test_torch.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     rng = jax.random.PRNGKey(1)
     rng, key = jax.random.split(rng, 2)
     key = jax.random.split(key, batch_size)
-    states, obs = env.v_reset(key)
+    obs, states = env.v_reset(key)
     t = 0
     while True:
         t += 1
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         action = torch2jax(action)
 
         key = jax.random.split(key, batch_size)
-        states, obs, r, d, ep_dones = env.v_step(states, action, key)
+        obs, states, r, d, ep_dones = env.v_step(states, action, key)
 
         # Move obs to torch
         torch_obs = jax2torch(obs)
@@ -43,4 +43,4 @@ if __name__ == "__main__":
         if jnp.any(ep_dones):
             print("resetting")
             rng, key = jax.random.split(rng, 2)
-            states, obs = env.reset_done_episodes(states, obs, ep_dones, key)
+            obs, states = env.reset_done_episodes(obs, states, ep_dones, key)

--- a/examples/test_vmap.py
+++ b/examples/test_vmap.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     rng = jax.random.PRNGKey(1)
     rng, key = jax.random.split(rng, 2)
     key = jax.random.split(key, batch_size)
-    states, obs = env.v_reset(key)
+    obs, states = env.v_reset(key)
     t = 0
     while True:
         t += 1
@@ -25,11 +25,11 @@ if __name__ == "__main__":
         key = jax.random.split(key, batch_size)
         # print("states.shape", states[0]["x"].shape)
         # print("actions.shape", actions.shape)
-        states, obs, r, d, ep_dones = env.v_step(states, actions, key)
+        obs, states, r, d, ep_dones = env.v_step(states, actions, key)
 
         print(f"t= {t}, ep_dones", ep_dones)
         # time.sleep(0.5)
         if jnp.any(ep_dones):
             print("resetting")
             rng, key = jax.random.split(rng, 2)
-            states, obs = env.reset_done_episodes(states, obs, ep_dones, key)
+            obs, states = env.reset_done_episodes(obs, states, ep_dones, key)

--- a/gigastep/evaluator.py
+++ b/gigastep/evaluator.py
@@ -484,7 +484,7 @@ def loop_env(env, policy=None, device="cpu", headless=False, swith_side = False)
                     action = evaluator.merge_actions(action_opp, action_ego)
 
                 rng, key = jax.random.split(rng, 2)
-                state, obs, r, dones, ep_done = env.step(state, action, key)
+                obs, state, r, dones, ep_done = env.step(state, action, key)
                 evaluator.update_step(r, dones, ep_done)
                 if not headless:
                     img = viewer.draw(env, state, obs)

--- a/gigastep/play_human.py
+++ b/gigastep/play_human.py
@@ -19,7 +19,7 @@ def main():
     while True:
         rng, key_reset = jax.random.split(rng, 2)
         ep_done = False
-        state, obs = env.reset(key_reset)
+        obs, state = env.reset(key_reset)
         total_user_reward = 0
         num_steps = 0
         while not ep_done:
@@ -41,7 +41,7 @@ def main():
             action = jnp.concatenate(
                 [jnp.expand_dims(action_user, 0), action_ai], axis=0
             )
-            state, obs, rewards, dones, ep_done = env.step(state, action, key_step)
+            obs, state, rewards, dones, ep_done = env.step(state, action, key_step)
             img = viewer.draw(env, state, obs)
             viewer.clock.tick(10)
             total_user_reward += rewards[0]

--- a/third-party-learning/evosax/problems/gigastep.py
+++ b/third-party-learning/evosax/problems/gigastep.py
@@ -130,7 +130,7 @@ class GigastepFitness(object):
             action_ado, _ = self.network(ado_policy_params, obs_ado, rng=rng_net)
             action = jnp.concatenate((action_ego, action_ado), axis=0)
 
-            next_s, next_o, reward, dones, done = self.env.step(
+            next_o, next_s, reward, dones, done = self.env.step(
                 state, action, rng_step
             )
 
@@ -222,7 +222,7 @@ class GigastepFitness(object):
             hidden_ado, action_ado, _ = self.network(ado_policy_params, obs_ado, hidden_ado, rng_net)
             action = jnp.concatenate((action_ego, action_ado), axis=0)
 
-            next_s, next_o, reward, dones, done = self.env.step(
+            next_o, next_s, reward, dones, done = self.env.step(
                 state, action, rng_step
             )
 

--- a/third-party-learning/purejax/cross_eval.py
+++ b/third-party-learning/purejax/cross_eval.py
@@ -47,7 +47,7 @@ class GigaStepWrapper(GymnaxWrapper):
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
         key, key_reset = jax.random.split(key)
-        state_st, obs_st, reward, done, episode_done = self._env.step(
+        obs_st, state_st, reward, done, episode_done = self._env.step(
             state, action, key
         )
         obs_re, state_re = self.reset(key_reset, params)

--- a/third-party-learning/purejax/ippo.py
+++ b/third-party-learning/purejax/ippo.py
@@ -47,7 +47,7 @@ class GigaStepWrapper(GymnaxWrapper):
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
         key, key_reset = jax.random.split(key)
-        state_st, obs_st, reward, done, episode_done = self._env.step(
+        obs_st, state_st, reward, done, episode_done = self._env.step(
             state, action, key
         )
         obs_re, state_re = self.reset(key_reset, params)
@@ -70,7 +70,7 @@ class GigaStepTupleObsWrapper(GigaStepWrapper):
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
         key, key_reset = jax.random.split(key)
-        state_st, obs_st, reward, done, episode_done = self._env.step(
+        obs_st, state_st, reward, done, episode_done = self._env.step(
             state, action, key
         )
         obs_re, state_re = self.reset(key_reset, params)

--- a/third-party-learning/purejax/replay.py
+++ b/third-party-learning/purejax/replay.py
@@ -46,7 +46,7 @@ class GigaStepWrapper(GymnaxWrapper):
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
         key, key_reset = jax.random.split(key)
-        state_st, obs_st, reward, done, episode_done = self._env.step(
+        obs_st, state_st, reward, done, episode_done = self._env.step(
             state, action, key
         )
         obs_re, state_re = self.reset(key_reset, params)
@@ -74,7 +74,7 @@ class GigaStepTupleObsWrapper(GigaStepWrapper):
         params: Optional[environment.EnvParams] = None,
     ) -> Tuple[chex.Array, environment.EnvState, float, bool, dict]:
         key, key_reset = jax.random.split(key)
-        state_st, obs_st, reward, done, episode_done = self._env.step(
+        obs_st, state_st, reward, done, episode_done = self._env.step(
             state, action, key
         )
         obs_re, state_re = self.reset(key_reset, params)

--- a/third-party-learning/purejax/test_bc.py
+++ b/third-party-learning/purejax/test_bc.py
@@ -59,7 +59,7 @@ def loop_user():
 
             action = jnp.where(is_ego[:, None], a1, a2)
             rng, key = jax.random.split(rng, 2)
-            state, obs, r, a, ep_done = env.step(state, action, key)
+            obs, state, r, a, ep_done = env.step(state, action, key)
             print(f"Step {t:04d} reward {r[0]:0.1f}")
             frame_buffer = viewer.draw(env, state, None)
             t += 1

--- a/third-party-learning/torch_ppo/enjoy_policy_discrete.py
+++ b/third-party-learning/torch_ppo/enjoy_policy_discrete.py
@@ -110,7 +110,7 @@ def evaluation_jax(env_name,obs_type,discrete_actions, actor_critic,actor_critic
 
 
             rng,key_step = jax.random.split(rng, 2)
-            state, obs, rewards, dones, ep_dones = env.step(state, action, key_step)
+            obs, state, rewards, dones, ep_dones = env.step(state, action, key_step)
             # obs is an uint8 array of shape [batch_size, n_agents, 84,84,3]
             # rewards is a float32 array of shape [batch_size, n_agents]
             # dones is a bool array of shape [batch_size, n_agents]

--- a/third-party-learning/torch_ppo/main.py
+++ b/third-party-learning/torch_ppo/main.py
@@ -298,7 +298,7 @@ def main(**sweep_dict):
                 rng, key_action, key_step = jax.random.split(rng, 3)
                 key_step = jax.random.split(key_step, int(args.batch_size))
 
-                state, obs, reward, agent_done, episode_done = envs.v_step(state, action_jax, key_step)
+                obs, state, reward, agent_done, episode_done = envs.v_step(state, action_jax, key_step)
 
                 step_agent += 1
 
@@ -328,7 +328,7 @@ def main(**sweep_dict):
                         step_agent[int(i)] = 0
                 if jnp.any(episode_done):
                     rng, key = jax.random.split(rng, 2)
-                    state, obs = envs.reset_done_episodes(state, obs, episode_done, key)
+                    obs, state = envs.reset_done_episodes(obs, state, episode_done, key)
                 obs = torch.tensor(np.asarray(obs)).to(device)
                 obs = torch.moveaxis(obs, -1, 2)
 
@@ -338,7 +338,7 @@ def main(**sweep_dict):
                 masks_agent = masks_agent_all[:, :n_ego_agents]
                 masks_agent_opponent = masks_agent_all[:, n_ego_agents:]
             else:
-                obs, reward, done, infos = envs.step(torch.squeeze(action))
+                obs, state, reward, done, infos = envs.step(torch.squeeze(action))
 
             masks_agent = masks_agent.unsqueeze(-1)
             masks_agent_opponent = masks_agent_opponent.unsqueeze(-1)


### PR DESCRIPTION
@mlech26l From the history of this repo, it looks like you intended to switch the order convention for 'obs, state'.  I had to finish the refactor to get the examples working again.  I didn't change gui_viewer.py, it is still using 'state, obs'

Finishing the refactor from "state, obs" to "obs, state" that was started in commit 952fcc7

Most of the examples run now, (some are failing because they call get_initial_state with a 'team' argument).